### PR TITLE
Configure automatic tree-shaking support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,6 @@ material/
 octicons/
 public/
 /index.d.ts
+/index.es5.js
 /index.js
 manifest.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Support automatic tree shaking ([#8](https://github.com/jacobwgillespie/styled-icons/pull/8))
+
 ## v1.1.1
 
 * Fix npm bundle (missing Font Awesome icons)

--- a/README.md
+++ b/README.md
@@ -3,11 +3,26 @@
 [![Build Status](https://travis-ci.org/jacobwgillespie/styled-icons.svg?branch=master)](https://travis-ci.org/jacobwgillespie/styled-icons)
 [![npm](https://img.shields.io/npm/dm/styled-icons.svg)](https://www.npmjs.com/package/styled-icons)
 [![npm](https://img.shields.io/npm/v/styled-icons.svg)](https://www.npmjs.com/package/styled-icons)
-![Built with TypeScript](https://img.shields.io/badge/built%20with-typescript-blue.svg)
+[![Built with Styled Components](https://img.shields.io/badge/built%20with-styled%20components-db7093.svg)](https://www.styled-components.com/)
+![Powered by TypeScript](https://img.shields.io/badge/powered%20by-typescript-blue.svg)
 
-`styled-icons` provides the [Font Awesome][4], [Material Design][2] and [Octicons][2] icon packs as [Styled Components][3], with full support for TypeScript types and ES6 modules / tree-shaking.
+[![View Icons](https://gui.apex.sh/component?name=ShadowButton&config=%7B%22text%22%3A%22ICON%20EXPLORER%22%2C%22color%22%3A%22db7093%22%7D)](https://styled-icons.js.org)
 
-[![View Icons](https://gui.apex.sh/component?name=ShadowButton&config=%7B%22text%22%3A%22ICON%20EXPLORER%22%2C%22color%22%3A%22db7093%22%7D)][0]
+`styled-icons` provides the [Font Awesome](https://fontawesome.com/), [Material Design](https://material.io/icons/) and [Octicons](https://octicons.github.com/) icon packs as [Styled Components](https://www.styled-components.com/), with full support for TypeScript types and tree-shaking / ES modules.
+
+---
+
+### Table of Contents
+
+* [Installation](#installation)
+* [Usage](#usage)
+  * [Props](#props)
+  * [Icon Dimensions](#icon-dimensions)
+  * [Styled Components](#styled-components)
+  * [Tree Shaking](#tree-shaking)
+  * [TypeScript](#typescript)
+* [Contributing](#contributing)
+* [License](#license)
 
 ## Installation
 
@@ -25,7 +40,7 @@ Additionally, you will need to have installed a version of `styled-components`, 
 
 ## Usage
 
-All Font Awesome (free), Material, and Octicon icons are available for preview at the [Icon Explorer][0].
+All Font Awesome (free), Material, and Octicon icons are available for preview at the [Icon Explorer](https://styled-icons.js.org).
 
 The entire icon packs are available via the main import and sub-imports:
 
@@ -64,7 +79,7 @@ import {Lock} from 'styled-icons/material'
 const App = () => <Lock size="48" />
 ```
 
-### Dimensions
+### Icon Dimensions
 
 Some icons natively have non-square dimensions - original dimensions are exported from the individual icon exports:
 
@@ -87,7 +102,7 @@ import {octicons} from 'styled-icons'
 
 ### Styled Components
 
-All icons are exported as [Styled Components][3], which means it is possible to extend their styles or otherwise utilize the Styled Components API:
+All icons are exported as [Styled Components](https://www.styled-components.com/), which means it is possible to extend their styles or otherwise utilize the Styled Components API:
 
 ```javascript
 import {Lock} from 'styled-icons/material'
@@ -98,6 +113,31 @@ export const RedLock = Lock.extend`
   font-weight: ${props => (props.important ? 'bold' : 'normal')};
 `
 ```
+
+### Tree Shaking
+
+**NOTE:** tree shaking should work without modification using [Create React App](https://github.com/facebook/create-react-app).
+
+Tree shaking has been tested with Create React App, Rollup, and Webpack. If your bundler is unable to import the icons, additional CommonJS/ES5 bundles are available:
+
+```javascript
+import React, {Fragment} from 'react'
+
+// This will result in all Material icons being bundled
+import {Account} from 'styled-icons/material.es5'
+
+// This will only include the Lock icon
+import {Lock} from 'styled-icons/material/Lock.es5'
+
+const App = () => (
+  <Fragment>
+    <Account />
+    <Lock />
+  </Fragment>
+)
+```
+
+Be aware though that importing from the plain ES5 icon pack bundles will likely result in significantly larger bundle sizes, because unused icons will be included in the final bundle. If you are unable to configure your bundler to process the ES module bundles, you should import icons individually to avoid large bundles.
 
 ### TypeScript
 
@@ -131,9 +171,3 @@ The Font Awesome icons are licensed under the [CC BY 4.0 License](https://github
 The Material Design icons are licensed under the [Apache License Version 2.0](https://github.com/google/material-design-icons/blob/master/LICENSE).
 
 The Octicons are licensed under the [MIT License](https://github.com/primer/octicons/blob/master/LICENSE).
-
-[0]: https://styled-icons.js.org
-[1]: https://material.io/icons/
-[2]: https://octicons.github.com/
-[3]: https://www.styled-components.com/
-[4]: https://github.com/FortAwesome/Font-Awesome

--- a/generate/templates/icon.tsx.template
+++ b/generate/templates/icon.tsx.template
@@ -1,4 +1,4 @@
-import * as React from 'react'
+import React from 'react'
 import styled from 'styled-components'
 
 import {StyledIcon, StyledIconProps} from '..'

--- a/package.json
+++ b/package.json
@@ -7,20 +7,23 @@
   "repository": "git://github.com/jacobwgillespie/styled-icons.git",
   "license": "MIT",
   "main": "index.js",
+  "module": "index.mjs",
+  "jsnext:main": "index.mjs",
   "typings": "./index.d.ts",
   "sideEffects": false,
   "files": [
-    "fa-brands",
-    "fa-regular",
-    "fa-solid",
-    "material",
-    "octicons",
-    "CHANGELOG.md",
-    "index.d.ts",
-    "index.js",
-    "LICENSE",
-    "package.json",
-    "README.md"
+    "/fa-brands",
+    "/fa-regular",
+    "/fa-solid",
+    "/material",
+    "/octicons",
+    "/CHANGELOG.md",
+    "/index.d.ts",
+    "/index.es5.js",
+    "/index.js",
+    "/LICENSE",
+    "/package.json",
+    "/README.md"
   ],
   "keywords": [
     "styled-components",
@@ -41,7 +44,7 @@
   "scripts": {
     "build": "node generate/generate.js",
     "build-website": "gatsby build",
-    "clean": "rm -rf build fa-brands fa-regular fa-solid material octicons public index.d.ts index.js",
+    "clean": "rm -rf build fa-brands fa-regular fa-solid material octicons public manifest.json index.d.ts index.es5.js index.js",
     "dev": "gatsby develop",
     "serve": "serve public"
   },

--- a/tsconfig.icons.es5.json
+++ b/tsconfig.icons.es5.json
@@ -1,0 +1,9 @@
+{
+  "extends": "./tsconfig.icons.json",
+  "compilerOptions": {
+    "declaration": false,
+    "module": "commonjs",
+    "outDir": "./build/icons-es5",
+    "target": "es5"
+  }
+}

--- a/tsconfig.icons.json
+++ b/tsconfig.icons.json
@@ -2,8 +2,10 @@
   "extends": "./tsconfig.json",
   "compilerOptions": {
     "declaration": true,
+    "module": "es2015",
     "outDir": "./build/icons",
-    "rootDir": "./build/typescript"
+    "rootDir": "./build/typescript",
+    "target": "es5"
   },
   "include": ["build/typescript"],
   "exclude": ["website"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     /* Basic Options */
-    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
+    "target": "es2015",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017','ES2018' or 'ESNEXT'. */
     "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', or 'ESNext'. */
     // "lib": [],                             /* Specify library files to be included in the compilation. */
     // "allowJs": true,                       /* Allow javascript files to be compiled. */
@@ -40,8 +40,8 @@
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
-    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    // "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */


### PR DESCRIPTION
This builds bundles as ES5 + ES modules and just plain ES5 - supports tree shaking automatically on Create React App, Webpack 4, and Rollup