### PR TITLE
Add decorative/standalone accessibility modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+* Improve accessibility with `title` prop
+
 ## v1.3.0
 
 * Add `css` prop for passing additional CSS

--- a/README.md
+++ b/README.md
@@ -145,7 +145,7 @@ Alternatively the icon could be used in standalone mode, meaning the icon itself
 <svg role="img"><title>Lock account</title> ...</svg>
 ```
 
-Since Style Icons accept all prop values of an `<svg>` element, you are free to override these `aria-*` attributes if you have a more complex use-case.
+Since Style Icons accept all `<svg>` element attributes as props, you are free to override these `aria-*` attributes if you have a more complex use-case.
 
 ### Tree Shaking
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
   * [Props](#props)
   * [Icon Dimensions](#icon-dimensions)
   * [Styled Components](#styled-components)
+  * [Accessibility](#accessibility)
   * [Tree Shaking](#tree-shaking)
   * [TypeScript](#typescript)
 * [Contributing](#contributing)
@@ -70,13 +71,21 @@ const App = () => (
 
 ### Props
 
-Styled Icons accept all the valid props of an `<svg />` element, in addition to a `size` convenience prop that sets both `width` and `height` and a `css` prop that accepts any valid Styled Components CSS (a string, a css tagged template literal, etc):
+Styled Icons accept all the valid props of an `<svg />` element, in addition to the following custom props:
+
+| Prop    | Required | Type                                                                                            | Description                                                                                                                                   |
+| ------- | -------- | ----------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- |
+| `size`  | optional | string, number                                                                                  | This is a convenience for setting both `width` and `height` to the same value                                                                 |
+| `title` | optional | string                                                                                          | This sets the icon title and enables the standalone icon accessability mode. See [accessibility](#accessibility) below for additional details |
+| `css`   | optional | string, function, [css tagged template literal](https://www.styled-components.com/docs/api#css) | This prop accepts additional CSS to attach to the icon. It accepts the CSS as a string or as any valid Style Components interpolation         |
+
+**Example**
 
 ```javascript
 import React from 'react'
 import {Lock} from 'styled-icons/material'
 
-const App = () => <Lock size="48" css="color: red;" />
+const App = () => <Lock size="48" title="Unlock account" css="color: red;" />
 ```
 
 ### Icon Dimensions
@@ -113,6 +122,30 @@ export const RedLock = Lock.extend`
   font-weight: ${props => (props.important ? 'bold' : 'normal')};
 `
 ```
+
+### Accessibility
+
+Styled Icons have two different built-in "modes" for accessibility purposes. By default, icons are considered decorative, meaning the icon is just visual sugar and the surrounding content is sufficient for conveying meaning. This will set the `aria-hidden` attribute on the resulting HTML to hide the icon from screen readers.
+
+```javascript
+// this icon
+<Lock />
+
+// will result in
+<svg aria-hidden="true">...</svg>
+```
+
+Alternatively the icon could be used in standalone mode, meaning the icon itself should convey meaning. This mode is enabled by setting a `title` prop - this is the text that will be read by a screen reader. This results in `role` being set to `img` and the addition of a `<title>` element.
+
+```javascript
+// this icon
+<Lock title="Lock account" />
+
+// will result in
+<svg role="img"><title>Lock account</title> ...</svg>
+```
+
+Since Style Icons accept all prop values of an `<svg>` element, you are free to override these `aria-*` attributes if you have a more complex use-case.
 
 ### Tree Shaking
 

--- a/generate/generate.js
+++ b/generate/generate.js
@@ -109,9 +109,14 @@ export {StyledIcon, StyledIconProps} from '..'
 
 ${PACKS.map((pack, idx) => `import * as ${fastCase.camelize(pack)} from './${pack}'`).join('\n')}
 
-export interface StyledIconProps<T> extends React.SVGProps<SVGSVGElement> {
-  size?: number | string
+export interface AriaAttributes {
+  'aria-hidden'?: string
+}
+
+export interface StyledIconProps<T> extends React.SVGProps<SVGSVGElement>, AriaAttributes {
   css?: Interpolation<ThemedStyledProps<StyledIconProps<T>, T>>
+  size?: number | string
+  title?: string | null
 }
 
 export interface StyledIcon<T = any> extends StyledComponentClass<StyledIconProps<T>, T> {}

--- a/generate/templates/icon.tsx.template
+++ b/generate/templates/icon.tsx.template
@@ -4,13 +4,16 @@ import styled from 'styled-components'
 import {StyledIcon, StyledIconProps} from '..'
 
 export const {{name}} = styled.svg.attrs({
-  children: [
-    {{svg}}
-  ],
-  'aria-hidden': 'true',
+  children: (props: StyledIconProps<any>) => (
+    props.title != null
+      ? [<title key="{{name}}-title">{props.title}</title>, {{svg}}]
+      : [{{svg}}]
+  ),
   viewBox: '{{viewBox}}',
   height: (props: StyledIconProps<any>) => (props.height !== undefined ? props.height : props.size),
   width: (props: StyledIconProps<any>) => (props.width !== undefined ? props.width : props.size),
+  'aria-hidden': (props: StyledIconProps<any>) => (props.title == null ? 'true' : undefined),
+  role: (props: StyledIconProps<any>) => (props.title != null ? 'img' : undefined),
 })`
   ${(props: StyledIconProps<any>) => props.css};
 ` as StyledIcon

--- a/generate/templates/icon.tsx.template
+++ b/generate/templates/icon.tsx.template
@@ -7,6 +7,7 @@ export const {{name}} = styled.svg.attrs({
   children: [
     {{svg}}
   ],
+  'aria-hidden': 'true',
   viewBox: '{{viewBox}}',
   height: (props: StyledIconProps<any>) => (props.height !== undefined ? props.height : props.size),
   width: (props: StyledIconProps<any>) => (props.width !== undefined ? props.width : props.size),

--- a/src/components/IconCard.js
+++ b/src/components/IconCard.js
@@ -33,7 +33,7 @@ export class IconCard extends React.PureComponent {
     return (
       <div className="icon-card" onClick={() => this.copy()}>
         <div>
-          <Icon size="48" />
+          <Icon size="48" title={`${name} icon`} />
         </div>
         <div className="name">{name}</div>
         <code>{this.state.copied ? 'Copied!' : this.iconImport}</code>

--- a/src/layouts/index.js
+++ b/src/layouts/index.js
@@ -25,7 +25,9 @@ const Layout = ({children, data}) => (
         />
       </svg>
     </a>
-    <Helmet title={data.site.siteMetadata.title} />
+    <Helmet title={data.site.siteMetadata.title}>
+      <html lang="en" />
+    </Helmet>
     {children()}
   </div>
 )


### PR DESCRIPTION
Allows controlling the accessibility mode via a `title` prop