### PR TITLE
Disable convertShapeToPath to fix broken icons

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Disable `convertShapeToPath` transformation that simplified icon SVGs as it was breaking certain icons
+
 ## v2.3.1
 
 - Fix issue where `.cjs` entrypoints required non-CommonJS files

--- a/generate/transform/svgo.js
+++ b/generate/transform/svgo.js
@@ -32,6 +32,7 @@ const svgoOptions = {
     {removeScriptElement: true},
     {removeTitle: true},
     {convertStyleToAttrs: false},
+    {convertShapeToPath: false},
     {removeStyleElement: true},
     {removeDimensions: true},
     {removeViewBox: false},


### PR DESCRIPTION
It's not a lossless transformation and it's breaking some Feather icons.

Fixes #233.