### PR TITLE
Add packs key to index so you can search for an entire pack

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -41,6 +41,7 @@ search.searchIndex = new JSSearch.UnorderedSearchIndex()
 search.indexStrategy = new JSSearch.AllSubstringsIndexStrategy()
 search.addIndex('name')
 search.addIndex('originalName')
+search.addIndex('pack')
 search.addDocuments(icons)
 
 const IndexPage = () => (


### PR DESCRIPTION
Hello!

I find myself wanting to search for the entire `material` pack on https://styled-icons.js.org/ - this pull request just adds the `'pack'` key to the search index