### PR TITLE
Let TypeScript automatically generate StyledIcon type

### DIFF
--- a/generate/generate.js
+++ b/generate/generate.js
@@ -141,7 +141,7 @@ const generate = async () => {
           .join('\n') +
           `
 
-export {StyledIcon, StyledIconProps} from '..${cjs ? '/index.cjs' : ''}'
+export {StyledIconProps} from '..${cjs ? '/index.cjs' : ''}'
 `,
       )
     }
@@ -149,7 +149,6 @@ export {StyledIcon, StyledIconProps} from '..${cjs ? '/index.cjs' : ''}'
     await fs.writeFileSync(
       path.join(baseDir, 'typescript', cjs ? 'index.cjs.ts' : 'index.ts'),
       `import * as React from 'react'
-import {StyledComponent} from 'styled-components'
 
 ${PACKS.map(
         (pack, idx) =>
@@ -161,8 +160,6 @@ export interface StyledIconProps extends React.SVGProps<SVGSVGElement> {
   size?: number | string
   title?: string | null
 }
-
-export interface StyledIcon<T extends object = {}> extends StyledComponent<React.ComponentType<any>, StyledIconProps, T> {}
 
 export {${PACKS.map(fastCase.camelize).join(', ')}}
 `,

--- a/generate/templates/icon.tsx.template
+++ b/generate/templates/icon.tsx.template
@@ -1,9 +1,9 @@
 import * as React from 'react'
 import styled from 'styled-components'
 
-import {StyledIcon, StyledIconProps} from '..{{cjs}}'
+import {StyledIconProps} from '..{{cjs}}'
 
-export const {{name}} = styled.svg.attrs<StyledIconProps>(props => ({
+export const {{name}} = styled.svg.attrs<any, StyledIconProps>(props => ({
   children: props.title != null
     ? [<title key="{{name}}-title">{props.title}</title>, {{svg}}]
     : [{{svg}}],
@@ -19,10 +19,8 @@ export const {{name}} = styled.svg.attrs<StyledIconProps>(props => ({
   display: inline-block;
   vertical-align: {{verticalAlign}};
   overflow: hidden;
-` as StyledIcon
+`
 
 {{name}}.displayName = '{{name}}'
 
 export const {{name}}Dimensions = {height: {{height}}, width: {{width}}}
-
-export {StyledIcon, StyledIconProps}


### PR DESCRIPTION
This skips explicitly defining a `StyledIcon` type and instead lets TypeScript auto-generate it from the `@types/styled-components` package.