### PR TITLE
Re-export a StyledIcon convenience type

### DIFF
--- a/generate/generate.js
+++ b/generate/generate.js
@@ -161,6 +161,8 @@ export interface StyledIconProps extends React.SVGProps<SVGSVGElement> {
   title?: string | null
 }
 
+export type StyledIcon = typeof import('./octicons/Alert').Alert
+
 export {${PACKS.map(fastCase.camelize).join(', ')}}
 `,
     )


### PR DESCRIPTION
Export an auto-generated `StyledIcon` TypeScript type.