### PR TITLE
Only pass valid SVG props to Styled Icons

### DIFF
--- a/packages/styled-icons/generate/templates/icon.tsx.template
+++ b/packages/styled-icons/generate/templates/icon.tsx.template
@@ -1,10 +1,11 @@
 import * as React from 'react'
 import styled from 'styled-components'
+import validProp from '@emotion/is-prop-valid'
 
 import {StyledIconProps} from '..{{cjs}}'
 
 const StyledIcon = React.forwardRef<SVGSVGElement, StyledIconProps>((props, ref) => {
-  const {title, size, ...svgProps} = props
+  const {title, size, ...otherProps} = props
 
   const iconProps: React.SVGProps<SVGSVGElement> = {
     viewBox: '{{viewBox}}',
@@ -16,6 +17,15 @@ const StyledIcon = React.forwardRef<SVGSVGElement, StyledIconProps>((props, ref)
     role: title != null ? 'img' : undefined,
     {{attrs}},
   }
+
+  const svgProps = Object.keys(otherProps).reduce(
+    (p, k) => {
+      if (validProp(k)) {
+        p[k] = otherProps[k]
+      }
+      return p
+    }, {}
+  )
 
   return (
     <svg {...iconProps} {...svgProps} ref={ref}>

--- a/packages/styled-icons/package.json
+++ b/packages/styled-icons/package.json
@@ -88,6 +88,7 @@
     "typicons.font": "^2.0.9"
   },
   "dependencies": {
-    "@babel/runtime": "^7.2.0"
+    "@babel/runtime": "^7.2.0",
+    "@emotion/is-prop-valid": "^0.7.3"
   }
 }


### PR DESCRIPTION
Fixes an issue where custom props get attached to the SVG element