### PR TITLE
 Fix issue where TypeScript evaluates all files

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,11 +211,11 @@ Be aware though that importing from the CommonJS icon pack bundles will likely r
 
 ### TypeScript
 
-The icons of `styled-icons` are built using TypeScript and export type definitions. If you need a type to reference any styled icon, there is a `StyledIcon` type exported from the root package import:
+The icons of `styled-icons` are built using TypeScript and export type definitions. If you need a type to reference any styled icon, there is a `StyledIcon` type exported from the `styled-icons/types` import:
 
 ```typescript
 import styled from 'styled-components'
-import {StyledIcon} from 'styled-icons'
+import {StyledIcon} from 'styled-icons/types'
 
 interface Props {
   icon: StyledIcon

--- a/packages/styled-icons/.gitignore
+++ b/packages/styled-icons/.gitignore
@@ -17,3 +17,7 @@ typicons/
 /index.cjs.d.ts
 /index.js
 /manifest.json
+/types.cjs.d.ts
+/types.cjs.js
+/types.d.ts
+/types.js

--- a/packages/styled-icons/README.md
+++ b/packages/styled-icons/README.md
@@ -211,11 +211,11 @@ Be aware though that importing from the CommonJS icon pack bundles will likely r
 
 ### TypeScript
 
-The icons of `styled-icons` are built using TypeScript and export type definitions. If you need a type to reference any styled icon, there is a `StyledIcon` type exported from the root package import:
+The icons of `styled-icons` are built using TypeScript and export type definitions. If you need a type to reference any styled icon, there is a `StyledIcon` type exported from the `styled-icons/types` import:
 
 ```typescript
 import styled from 'styled-components'
-import {StyledIcon} from 'styled-icons'
+import {StyledIcon} from 'styled-icons/types'
 
 interface Props {
   icon: StyledIcon

--- a/packages/styled-icons/generate/templates/icon.tsx.template
+++ b/packages/styled-icons/generate/templates/icon.tsx.template
@@ -2,7 +2,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import validProp from '@emotion/is-prop-valid'
 
-import {StyledIconProps} from '..{{cjs}}'
+import {StyledIconProps} from '../types{{cjs}}'
 
 const StyledIcon = React.forwardRef<SVGSVGElement, StyledIconProps>((props, ref) => {
   const {title, size, ...otherProps} = props

--- a/packages/styled-icons/package.json
+++ b/packages/styled-icons/package.json
@@ -28,7 +28,11 @@
     "/index.d.ts",
     "/index.cjs.js",
     "/index.js",
-    "/README.md"
+    "/README.md",
+    "/types.cjs.d.ts",
+    "/types.cjs.js",
+    "/types.d.ts",
+    "/types.js"
   ],
   "keywords": [
     "styled-components",
@@ -43,7 +47,7 @@
   ],
   "scripts": {
     "build": "node generate/generate.js && cp ../../README.md .",
-    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto fa-brands fa-regular fa-solid feather icomoon material octicons typicons public manifest.json index.d.ts index.cjs.js index.js"
+    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto fa-brands fa-regular fa-solid feather icomoon material octicons typicons public manifest.json index.d.ts index.cjs.js index.js types.cjs.d.ts types.cjs.js types.d.ts types.js"
   },
   "peerDependencies": {
     "react": "*",


### PR DESCRIPTION
Due to the fact that all icons currently import directly from `styled-icons`, this causes the TypeScript compiler to evaluate all icon files in any project, even if that project only imports a single icon.  This is _slow_.

This PR adds a new `styled-icons/types` import which untangles the dependency graph and allows TS to only parse imported files.