### PR TITLE
Remove string ref from StyledIconProps interface

### DIFF
--- a/packages/styled-icons/generate/templates/StyledIconBase.tsx
+++ b/packages/styled-icons/generate/templates/StyledIconBase.tsx
@@ -2,7 +2,7 @@ import * as React from 'react'
 import styled from 'styled-components'
 import validProp from '@emotion/is-prop-valid'
 
-export interface StyledIconProps extends React.SVGProps<SVGSVGElement> {
+export interface StyledIconProps extends React.PropsWithRef<React.SVGProps<SVGSVGElement>> {
   'aria-hidden'?: string
   size?: number | string
   title?: string | null


### PR DESCRIPTION
`StyledIconProps` currently allows a string `ref`, which is invalid for a Styled Component.  This filters out the string ref.