### PR TITLE
Rename Package icon to PackageIcon

### DIFF
--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -127,6 +127,9 @@ const generate = async () => {
     // Special-case the `React` icon
     if (icon.name === 'React') icon.name = 'ReactLogo'
 
+    // Special-case the `Package` icon (conflicts with the package.json file)
+    if (icon.name === 'Package') icon.name = 'PackageIcon'
+
     const component = () =>
       template
         .replace(/{{attrs}}/g, JSON.stringify(icon.attrs, null, 2).slice(2, -2))


### PR DESCRIPTION
On case-insensitive filesystems, `styled-icons/pack-name/Package` matches the `package.json` file rather than the `Package` directory.  This PR renames the `Package` icon to `PackageIcon`.

Fixes #822 
Fixes #821 