### PR TITLE
Add OpenSearch description file

### DIFF
--- a/packages/website/pages/_document.tsx
+++ b/packages/website/pages/_document.tsx
@@ -103,6 +103,13 @@ export default class MyDocument extends Document {
           <link rel="shortcut icon" href="/icons/icon-48x48.png" />
           <link rel="manifest" href="/manifest.webmanifest" />
           <meta name="theme-color" content="#db7093" />
+
+          <link
+            rel="search"
+            type="application/opensearchdescription+xml"
+            title="Styled Icons"
+            href="/opensearch.xml"
+          />
         </Head>
         <body className="custom_class">
           <Main />

--- a/packages/website/public/opensearch.xml
+++ b/packages/website/public/opensearch.xml
@@ -1,0 +1,9 @@
+<OpenSearchDescription xmlns="http://a9.com/-/spec/opensearch/1.1/" xmlns:moz="http://www.mozilla.org/2006/browser/search/">
+  <ShortName>Styled Icons</ShortName>
+  <Description>A Styled Components icon library</Description>
+  <Url type="text/html" method="GET" template="https://styled-icons.js.org/?s={searchTerms}"/>
+  <Url type="application/opensearchdescription+xml" rel="self" template="/opensearch.xml" />
+  <Image width="16" height="16">https://styled-icons.js.org/icons/favicon.ico</Image>
+  <InputEncoding>UTF-8</InputEncoding>
+  <moz:SearchForm>https://styled-icons.js.org</moz:SearchForm>
+</OpenSearchDescription>


### PR DESCRIPTION
This adds the OpenSearch description file which allows searching the website from the address bar. It is very handy and often I go to the website to search for icons. This makes that process easier.

You can read more about it here https://developer.mozilla.org/en-US/docs/Web/OpenSearch

**NOTE:** I was unable to get `yarn` to successfully run. It kept timing out on material-design-icons.
**NOTE:** I also noticed that you have 2 manifests, currently and both are referenced in  `_document.tsx`. One at `public/icons/manifest.json` and another at public/manifest.webmanifest`. This would be good to fix IMO.