### PR TITLE
Fix feather icons

### DIFF
--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -126,8 +126,8 @@ const generate = async () => {
       }
     }
 
-    // If the base icon has a fill of `none`, replace it
-    if (icon.attrs.fill === 'none') {
+    // If the base icon has a fill of `none`, replace it unless stroke is the desired effect
+    if (icon.attrs.fill === 'none' && icon.attrs.stroke !== 'currentColor') {
       icon.attrs.fill = 'currentColor'
     }
 

--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -126,11 +126,6 @@ const generate = async () => {
       }
     }
 
-    // If the base icon has a fill of `none`, replace it unless stroke is the desired effect
-    if (icon.attrs.fill === 'none' && icon.attrs.stroke !== 'currentColor') {
-      icon.attrs.fill = 'currentColor'
-    }
-
     // Special-case the `React` icon
     if (icon.name === 'React') icon.name = 'ReactLogo'
 

--- a/packages/styled-icons/generate/transform/svgo.js
+++ b/packages/styled-icons/generate/transform/svgo.js
@@ -37,7 +37,7 @@ const svgoOptions = {
     {removeDimensions: true},
     {removeViewBox: false},
     {addKeyPropToChildren},
-    {removeAttrs: {attrs: ['id', '*:(stroke|fill):((?!^none$).)*']}},
+    {removeAttrs: {attrs: ['id', '*:(stroke|fill):((?!^none$)(?!^currentColor$).)*']}},
     {sortAttrs: true},
   ],
 }


### PR DESCRIPTION
Fixes #945 

Currently, we overwrite any `fill="none"` with `fill="currentColor". In the case of the feather icon pack, they specifically use `stroke="currentColor"`. This change maintains the `fill="none"` if using `stroke="currentColor"`. Feels a _bit_ on the fragile side but should address the issue.

Also, the regex that I provided to SVGO for `removeAttrs` was a bit aggressive in #938. So I modified it to also maintain the value `currentColor`. This _should_ allow for us to maintain properly set up icons.

Ran locally to verify:

![image](https://user-images.githubusercontent.com/855184/64544419-970f7c00-d2ec-11e9-9da9-f1533bf0dd70.png)

Did a quick skim on each icon pack as well. I didn't immediately notice anything standing out/broken. @jacobwgillespie Would love to see if we could get some visual regression tests for all the icons automated so it would be easier to tell if changes are going to break an icon or icon pack.