### PR TITLE
Add material variants

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,10 @@ import * as faSolid from 'styled-icons/fa-solid'
 import * as feather from 'styled-icons/feather'
 import * as icomoon from 'styled-icons/icomoon'
 import * as material from 'styled-icons/material'
+import * as materialOutlined from 'styled-icons/material-outlined'
+import * as materialRounded from 'styled-icons/material-rounded'
+import * as materialTwoTone from 'styled-icons/material-twotone'
+import * as materialSharp from 'styled-icons/material-sharp'
 import * as octicons from 'styled-icons/octicons'
 import * as typicons from 'styled-icons/typicons'
 ```
@@ -199,7 +203,7 @@ interface Props {
 }
 ```
 
-**NOTE:** you should ensure that the version of `@types/react` in your project is at least `16.8.14` or greater.  That version of the React types package added support for ARIA attributes on SVG elements, which Styled Icons uses.
+**NOTE:** you should ensure that the version of `@types/react` in your project is at least `16.8.14` or greater. That version of the React types package added support for ARIA attributes on SVG elements, which Styled Icons uses.
 
 If you have any ideas for improvements to the TypeScript typing, please open an issue or PR!
 

--- a/packages/styled-icons/.gitignore
+++ b/packages/styled-icons/.gitignore
@@ -11,6 +11,10 @@ fa-solid/
 icomoon/
 feather/
 material/
+material-outlined/
+material-rounded/
+material-twotone/
+material-sharp/
 octicons/
 StyledIconBase/
 types/

--- a/packages/styled-icons/README.md
+++ b/packages/styled-icons/README.md
@@ -60,6 +60,10 @@ import * as faSolid from 'styled-icons/fa-solid'
 import * as feather from 'styled-icons/feather'
 import * as icomoon from 'styled-icons/icomoon'
 import * as material from 'styled-icons/material'
+import * as materialOutlined from 'styled-icons/material-outlined'
+import * as materialRounded from 'styled-icons/material-rounded'
+import * as materialTwoTone from 'styled-icons/material-twotone'
+import * as materialSharp from 'styled-icons/material-sharp'
 import * as octicons from 'styled-icons/octicons'
 import * as typicons from 'styled-icons/typicons'
 ```
@@ -199,7 +203,7 @@ interface Props {
 }
 ```
 
-**NOTE:** you should ensure that the version of `@types/react` in your project is at least `16.8.14` or greater.  That version of the React types package added support for ARIA attributes on SVG elements, which Styled Icons uses.
+**NOTE:** you should ensure that the version of `@types/react` in your project is at least `16.8.14` or greater. That version of the React types package added support for ARIA attributes on SVG elements, which Styled Icons uses.
 
 If you have any ideas for improvements to the TypeScript typing, please open an issue or PR!
 

--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -20,6 +20,10 @@ const PACKS = [
   'feather',
   'icomoon',
   'material',
+  'material-outlined',
+  'material-rounded',
+  'material-sharp',
+  'material-twotone',
   'octicons',
   'typicons',
 ]

--- a/packages/styled-icons/generate/sources/material-outlined.js
+++ b/packages/styled-icons/generate/sources/material-outlined.js
@@ -1,0 +1,19 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = async () => {
+  const baseDir = path.dirname(require.resolve('material-design-icons-updated'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/outline/*/*24px.svg'))
+
+  return sourceFiles.map(filename => {
+    const match = filename.match(/ic_(.*)_(((\d+)x)?[\d]+px)\.svg$/)
+    return {
+      originalName: match[1],
+      source: fs.readFileSync(filename).toString(),
+      pack: 'material-outlined',
+      width: match[4] || '24',
+      height: '24',
+    }
+  })
+}

--- a/packages/styled-icons/generate/sources/material-rounded.js
+++ b/packages/styled-icons/generate/sources/material-rounded.js
@@ -1,0 +1,19 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = async () => {
+  const baseDir = path.dirname(require.resolve('material-design-icons-updated'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/round/*/*24px.svg'))
+
+  return sourceFiles.map(filename => {
+    const match = filename.match(/ic_(.*)_(((\d+)x)?[\d]+px)\.svg$/)
+    return {
+      originalName: match[1],
+      source: fs.readFileSync(filename).toString(),
+      pack: 'material-rounded',
+      width: match[4] || '24',
+      height: '24',
+    }
+  })
+}

--- a/packages/styled-icons/generate/sources/material-sharp.js
+++ b/packages/styled-icons/generate/sources/material-sharp.js
@@ -1,0 +1,19 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = async () => {
+  const baseDir = path.dirname(require.resolve('material-design-icons-updated'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/sharp/*/*24px.svg'))
+
+  return sourceFiles.map(filename => {
+    const match = filename.match(/ic_(.*)_(((\d+)x)?[\d]+px)\.svg$/)
+    return {
+      originalName: match[1],
+      source: fs.readFileSync(filename).toString(),
+      pack: 'material-sharp',
+      width: match[4] || '24',
+      height: '24',
+    }
+  })
+}

--- a/packages/styled-icons/generate/sources/material-twotone.js
+++ b/packages/styled-icons/generate/sources/material-twotone.js
@@ -1,0 +1,19 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = async () => {
+  const baseDir = path.dirname(require.resolve('material-design-icons-updated'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/twotone/*/*24px.svg'))
+
+  return sourceFiles.map(filename => {
+    const match = filename.match(/ic_(.*)_(((\d+)x)?[\d]+px)\.svg$/)
+    return {
+      originalName: match[1],
+      source: fs.readFileSync(filename).toString(),
+      pack: 'material-twotone',
+      width: match[4] || '24',
+      height: '24',
+    }
+  })
+}

--- a/packages/styled-icons/package.json
+++ b/packages/styled-icons/package.json
@@ -23,6 +23,10 @@
     "/icomoon",
     "/manifest.json",
     "/material",
+    "/material-outlined",
+    "/material-rounded",
+    "/material-twotone",
+    "/material-sharp",
     "/octicons",
     "/StyledIconBase",
     "/types",
@@ -45,7 +49,7 @@
   ],
   "scripts": {
     "build": "node generate/generate.js && cp ../../README.md .",
-    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto evil fa-brands fa-regular fa-solid feather icomoon material octicons StyledIconBase types typicons public manifest.json index.d.ts index.esm.js index.js"
+    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto evil fa-brands fa-regular fa-solid feather icomoon material material-outlined material-rounded material-twotone material-sharp octicons StyledIconBase types typicons public manifest.json index.d.ts index.esm.js index.js"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/website/src/components/IconExplorer.tsx
+++ b/packages/website/src/components/IconExplorer.tsx
@@ -18,6 +18,10 @@ import {
   feather,
   icomoon,
   material,
+  materialOutlined,
+  materialRounded,
+  materialTwotone,
+  materialSharp,
   octicons,
   typicons,
 } from 'styled-icons'
@@ -68,6 +72,18 @@ const icons = iconManifest.map(
 
       case 'material':
         return {...icon, icon: material[icon.name as keyof typeof material]}
+
+      case 'material-outlined':
+        return {...icon, icon: materialOutlined[icon.name as keyof typeof materialOutlined]}
+
+      case 'material-rounded':
+        return {...icon, icon: materialRounded[icon.name as keyof typeof materialRounded]}
+
+      case 'material-twotone':
+        return {...icon, icon: materialTwotone[icon.name as keyof typeof materialTwotone]}
+
+      case 'material-sharp':
+        return {...icon, icon: materialSharp[icon.name as keyof typeof materialSharp]}
 
       case 'octicons':
         return {...icon, icon: octicons[icon.name as keyof typeof octicons]}


### PR DESCRIPTION
Having issues with the website build running out of memory. Tried specifying `NODE_OPTIONS` but no luck.

This would add the other material variants without any breaking changes. Fixes #932 