### PR TITLE
Add custom icon helper

### DIFF
--- a/packages/styled-icons/generate/createIcon.tsx
+++ b/packages/styled-icons/generate/createIcon.tsx
@@ -1,0 +1,116 @@
+import * as React from 'react'
+import {StyledIconBase, StyledIconProps} from './templates/StyledIconBase'
+
+type SVGProps<T = SVGElement> = React.SVGProps<T>
+
+const SVG_ATTRS = [
+  'fill',
+  'fillOpacity',
+  'fillRule',
+  'stroke',
+  'strokeDasharray',
+  'strokeDashoffset',
+  'strokeLinecap',
+  'strokeLinejoin',
+  'strokeMiterlimit',
+  'strokeOpacity',
+] as const
+
+const coloringProps = ['stroke', 'fill'] as const
+const allowedValues = ['none', 'currentColor']
+
+const unallowedElements = ['script', 'title', 'style', 'desc', 'metadata']
+const unallowedProps = ['xlmns', 'style']
+
+// Quick and Dirty SVGO implementation
+function svgo(element: JSX.Element) {
+  // Remove unallowed elements
+  if (unallowedElements.includes(element.type)) return
+  // Handle element  without props
+  if (!element.props) return element
+  // Remove unallowed props
+  // TODO: Object.fromEntries
+  const optimizedProps = Object.keys(element.props)
+    .filter(prop => !unallowedProps.includes(prop))
+    .reduce<SVGProps>((acc, key) => {
+      // @ts-ignore
+      acc[key] = element.props[key]
+      return acc
+    }, {})
+
+  // Handle stroke and fill explicitly
+  coloringProps.forEach(prop => {
+    if (optimizedProps[prop] && !allowedValues.includes(optimizedProps[prop]!)) {
+      delete optimizedProps[prop]
+    }
+  })
+
+  if (element.props.children) {
+    optimizedProps.children = React.Children.map(element.props.children, svgo)
+  }
+
+  return React.createElement(element.type, optimizedProps)
+}
+
+const defaultSize = 24
+
+export default function createIcon(
+  svg: JSX.Element,
+  {
+    width: defaultWidth = defaultSize,
+    height: defaultHeight = defaultSize,
+    verticalAlign = 'middle',
+  }: Partial<{
+    width: number | string
+    height: number | string
+    verticalAlign: string
+  }> = {},
+) {
+  if (process.env.NODE_ENV !== 'production') {
+    if (!React.isValidElement(svg)) {
+      throw new Error('An element must be provided')
+    }
+    if (svg.type !== 'svg') {
+      throw new Error(
+        `Invalid Element of type ${svg.type} provided. You must provide an svg element`,
+      )
+    }
+  }
+
+  // Optimize SVG
+  const optimizedSvg = svgo(svg)!
+  const svgProps = optimizedSvg.props
+
+  // Quick and dirty H2X processSVG
+  const height = svgProps.height || defaultHeight
+  const width = svgProps.width || defaultWidth
+  const {viewBox = `0 0 ${width} ${height}`, children} = svgProps
+  const attrs: SVGProps<SVGSVGElement> = {
+    fill: 'currentColor',
+    xmlns: 'http://www.w3.org/2000/svg',
+  }
+
+  // Pick specific attrs to pass through
+  for (const attr of SVG_ATTRS) {
+    if (attr in svgProps) {
+      // @ts-ignore
+      attrs[attr] = svgProps[attr]
+    }
+  }
+
+  // Create Icon
+  return Object.assign(
+    React.forwardRef<SVGSVGElement, StyledIconProps>((props, ref) => (
+      <StyledIconBase
+        iconAttrs={attrs}
+        iconVerticalAlign={verticalAlign}
+        iconViewBox={viewBox}
+        {...props}
+        ref={ref}
+      >
+        {children}
+      </StyledIconBase>
+    )),
+    {dimensions: {width, height}},
+  )
+}


### PR DESCRIPTION
Fixes #477

@jacobwgillespie Let me know your thoughts and I will clean this up and get it ready to be merged.


Interested to hear everyone's opinion!

Here is a playground to test it. https://codesandbox.io/s/react-typescript-playground-jrj1k

Usage:

```jsx
import styled from 'styled-components'
import { createIcon } from 'styled-icons'

const Icon = createIcon(
  <svg viewBox="0 0 24 24" fill="currentColor">
		<path
			fill="currentColor"
			d="M13 4c-3.859 0-7 3.141-7 7 0 .763.127 1.495.354 2.183l-.749.75-.511.512-1.008 1.045a3.076 3.076 0 0 0-.891 2.185 3.134 3.134 0 0 0 3.13 3.131c.757 0 1.504-.278 2.104-.784l.064-.055.061-.061 1.512-1.51.75-.749A6.983 6.983 0 0 0 13 18c3.859 0 7-3.141 7-7s-3.141-7-7-7zm0 12c-2.757 0-5-2.243-5-5s2.243-5 5-5 5 2.243 5 5-2.243 5-5 5zm0-9c-2.205 0-4 1.794-4 4s1.795 4 4 4 4-1.794 4-4-1.795-4-4-4zm0 7a3.001 3.001 0 0 1 0-6 3.001 3.001 0 0 1 0 6z"
		/>
	</svg>
)

const Chrome = createIcon(
  <svg
		viewBox="0 0 24 24"
		height="48"
		width="48"
		fill="currentColor"
		xmlns="http://www.w3.org/2000/svg">
		<title>Chrome icon</title>
		<path d="M10.742 2.04c-1.404.183-3.06.808-4.281 1.626-1.01.664-2.397 2.02-2.309 2.251.193.501 3.28 5.658 3.33 5.562.038-.067.095-.279.123-.49.25-1.385 1.425-2.704 2.897-3.253.568-.221.683-.221 5.495-.27l4.917-.047-.395-.646c-1.385-2.26-3.522-3.819-6.197-4.512-.731-.193-2.81-.318-3.58-.22z" />
		<path d="M3.2 7.217c-.453.799-.983 2.415-1.107 3.358-.588 4.273 1.568 8.4 5.379 10.315.894.452 2.174.885 2.732.933l.356.029 1.674-2.838c.915-1.559 1.655-2.849 1.636-2.868-.02-.019-.231.039-.481.125-1.569.53-3.387.086-4.57-1.116-.424-.424-1.002-1.357-2.84-4.542C4.71 8.41 3.642 6.601 3.603 6.601c-.028 0-.211.279-.403.616z" />
		<path d="M15.15 8.804c1.222 1.242 1.655 3.003 1.116 4.59-.086.26-1.212 2.271-2.501 4.485-1.29 2.203-2.349 4.031-2.349 4.06 0 .115 1.328.057 2.175-.087 4.32-.74 7.573-4.002 8.265-8.276.26-1.558.164-2.925-.307-4.503l-.25-.837h-6.707l.557.568z" />
		<path d="M10.608 8.563C9.598 8.987 8.905 9.7 8.53 10.71c-.173.453-.202.713-.173 1.424.03.75.068.963.347 1.511.366.75.962 1.329 1.751 1.703.462.221.654.25 1.54.25.895 0 1.077-.029 1.559-.26.712-.326 1.462-1.077 1.79-1.79.23-.48.259-.663.259-1.558 0-.886-.029-1.078-.25-1.54-.375-.788-.952-1.386-1.703-1.75-.568-.28-.742-.318-1.56-.348-.788-.019-.99.01-1.48.213z" />
	</svg>
)

const FeatherActivity = createIcon(
	<svg
		viewBox="0 0 24 24"
		width="24"
		height="24"
		stroke="currentColor"
		strokeWidth="2"
		fill="none"
		strokeLinecap="round"
		strokeLinejoin="round">
		<polyline points="22 12 18 12 15 21 9 3 6 12 2 12" />
		{/* test */}
	</svg>
)

const StyledIcon = styled(Icon)`
  color: blue;
`

const C = () => (
  <>
    <Chrome size={100} />
    <FeatherActivity style={{ color: 'red' }} />
    <StyledIcon size="1em" />
  </>
)
```

This part is untested but I _think_ you can use CRA's ReactComponent import to get the icons.

```
import { ReactComponent as Icon } from './my-path/icon.svg'

const CustomIcon = createIcon(<Icon />)
```