### PR TITLE
Add remix icons

### DIFF
--- a/packages/styled-icons/.gitignore
+++ b/packages/styled-icons/.gitignore
@@ -1,17 +1,20 @@
-# Built files
+# Built Icon Packs
 boxicons-logos/
 boxicons-regular/
 boxicons-solid/
-build/
 crypto/
 evil/
 fa-brands/
 fa-regular/
 fa-solid/
-icomoon/
 feather/
+icomoon/
 material/
 octicons/
+remix/
+
+# Built files
+build/
 StyledIconBase/
 types/
 typicons/

--- a/packages/styled-icons/.gitignore
+++ b/packages/styled-icons/.gitignore
@@ -11,13 +11,14 @@ feather/
 icomoon/
 material/
 octicons/
-remix/
+remix-fill/
+remix-line/
+typicons/
 
 # Built files
 build/
 StyledIconBase/
 types/
-typicons/
 
 /index.d.ts
 /index.esm.js

--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -134,6 +134,9 @@ const generate = async () => {
     // Special-case the `Package` icon (conflicts with the package.json file)
     if (icon.name === 'Package') icon.name = 'PackageIcon'
 
+    // Special-case the `BookMark` icon (conflicts with the `Bookmark` icon)
+    if (icon.name === 'BookMark') icon.name = 'BookWithMark'
+
     const component = () =>
       template
         .replace(/{{attrs}}/g, JSON.stringify(icon.attrs, null, 2).slice(2, -2))

--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -9,6 +9,7 @@ const h2x = require('./transform/h2x')
 const svgo = require('./transform/svgo')
 
 const PACKS = [
+  'remix',
   'boxicons-logos',
   'boxicons-regular',
   'boxicons-solid',
@@ -235,7 +236,7 @@ export {StyledIconProps}
   compiler.stderr.pipe(process.stderr)
   await compiler
 
-  console.log('Moving ESM JavaScript files...')
+  console.log('Moving CJS JavaScript files...')
   const cjsFiles = await fg('build/**/*.js')
   for (const builtFile of cjsFiles) {
     const destination = path.join(__dirname, '..', builtFile.replace('build/', ''))

--- a/packages/styled-icons/generate/generate.js
+++ b/packages/styled-icons/generate/generate.js
@@ -9,7 +9,6 @@ const h2x = require('./transform/h2x')
 const svgo = require('./transform/svgo')
 
 const PACKS = [
-  'remix',
   'boxicons-logos',
   'boxicons-regular',
   'boxicons-solid',
@@ -22,6 +21,8 @@ const PACKS = [
   'icomoon',
   'material',
   'octicons',
+  'remix-fill',
+  'remix-line',
   'typicons',
 ]
 

--- a/packages/styled-icons/generate/sources/remix-fill.js
+++ b/packages/styled-icons/generate/sources/remix-fill.js
@@ -4,14 +4,14 @@ const path = require('path')
 
 module.exports = async () => {
   const baseDir = path.dirname(require.resolve('remixicon/package.json'))
-  const sourceFiles = await fg(path.join(baseDir, 'icons/*/*.svg'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/*/*-fill.svg'))
 
   return sourceFiles.map(filename => {
-    const match = filename.match(/([\w-]*)\.svg$/)
+    const match = filename.match(/([\w-]*)\-fill\.svg$/)
     return {
       originalName: match[1],
       source: fs.readFileSync(filename).toString(),
-      pack: 'remix',
+      pack: 'remix-fill',
       width: '24',
       height: '24',
     }

--- a/packages/styled-icons/generate/sources/remix-line.js
+++ b/packages/styled-icons/generate/sources/remix-line.js
@@ -1,0 +1,19 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = async () => {
+  const baseDir = path.dirname(require.resolve('remixicon/package.json'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/*/*-line.svg'))
+
+  return sourceFiles.map(filename => {
+    const match = filename.match(/([\w-]*)\-line\.svg$/)
+    return {
+      originalName: match[1],
+      source: fs.readFileSync(filename).toString(),
+      pack: 'remix-line',
+      width: '24',
+      height: '24',
+    }
+  })
+}

--- a/packages/styled-icons/generate/sources/remix.js
+++ b/packages/styled-icons/generate/sources/remix.js
@@ -1,0 +1,19 @@
+const fg = require('fast-glob')
+const fs = require('fs-extra')
+const path = require('path')
+
+module.exports = async () => {
+  const baseDir = path.dirname(require.resolve('remixicon/package.json'))
+  const sourceFiles = await fg(path.join(baseDir, 'icons/*/*.svg'))
+
+  return sourceFiles.map(filename => {
+    const match = filename.match(/([\w-]*)\.svg$/)
+    return {
+      originalName: match[1],
+      source: fs.readFileSync(filename).toString(),
+      pack: 'remix',
+      width: '24',
+      height: '24',
+    }
+  })
+}

--- a/packages/styled-icons/package.json
+++ b/packages/styled-icons/package.json
@@ -24,10 +24,11 @@
     "/manifest.json",
     "/material",
     "/octicons",
-    "/remix",
+    "/remix-fill",
+    "/remix-line",
+    "/typicons",
     "/StyledIconBase",
     "/types",
-    "/typicons",
     "/index.d.ts",
     "/index.esm.js",
     "/index.js",
@@ -46,7 +47,7 @@
   ],
   "scripts": {
     "build": "node generate/generate.js && cp ../../README.md .",
-    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto evil fa-brands fa-regular fa-solid feather icomoon material octicons remix StyledIconBase types typicons public manifest.json index.d.ts index.esm.js index.js"
+    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid crypto evil fa-brands fa-regular fa-solid feather icomoon material octicons remix-fill remix-line typicons build StyledIconBase types public manifest.json index.d.ts index.esm.js index.js"
   },
   "peerDependencies": {
     "react": "*",

--- a/packages/styled-icons/package.json
+++ b/packages/styled-icons/package.json
@@ -24,6 +24,7 @@
     "/manifest.json",
     "/material",
     "/octicons",
+    "/remix",
     "/StyledIconBase",
     "/types",
     "/typicons",
@@ -45,7 +46,7 @@
   ],
   "scripts": {
     "build": "node generate/generate.js && cp ../../README.md .",
-    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto evil fa-brands fa-regular fa-solid feather icomoon material octicons StyledIconBase types typicons public manifest.json index.d.ts index.esm.js index.js"
+    "clean": "rm -rf boxicons-logos boxicons-regular boxicons-solid build crypto evil fa-brands fa-regular fa-solid feather icomoon material octicons remix StyledIconBase types typicons public manifest.json index.d.ts index.esm.js index.js"
   },
   "peerDependencies": {
     "react": "*",
@@ -75,6 +76,7 @@
     "number-to-words": "^1.2.3",
     "react": "^16.8.5",
     "react-dom": "^16.8.5",
+    "remixicon": "^2.0.0",
     "styled-components": "^4.3.2",
     "svgo": "^1.3.0",
     "ts-node": "^8.3.0",

--- a/packages/website/src/components/IconExplorer.tsx
+++ b/packages/website/src/components/IconExplorer.tsx
@@ -20,6 +20,8 @@ import {
   material,
   octicons,
   typicons,
+  remixFill,
+  remixLine,
 } from 'styled-icons'
 import iconManifest from 'styled-icons/manifest.json'
 
@@ -71,6 +73,12 @@ const icons = iconManifest.map(
 
       case 'octicons':
         return {...icon, icon: octicons[icon.name as keyof typeof octicons]}
+
+      case 'remix-fill':
+        return {...icon, icon: remixFill[icon.name as keyof typeof remixFill]}
+
+      case 'remix-line':
+        return {...icon, icon: remixLine[icon.name as keyof typeof remixLine]}
 
       case 'typicons':
         return {...icon, icon: typicons[icon.name as keyof typeof typicons]}

--- a/yarn.lock
+++ b/yarn.lock
@@ -10258,6 +10258,11 @@ regjsparser@^0.6.0:
   dependencies:
     jsesc "~0.5.0"
 
+remixicon@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/remixicon/-/remixicon-2.0.0.tgz#65ba15651ed575882f1e4059b9aae7d14625d9ee"
+  integrity sha512-dXCuXawug6pegCsYtOaHIQIg1DHvKwOk3WzK2pvS+nNw/3dDn/ezHoQhoZWjZS/iGOx75nXvwHwSJS7znHVv3w==
+
 remove-trailing-separator@^1.0.1:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz#c24bce2a283adad5bc3f58e0d48249b92379d8ef"


### PR DESCRIPTION
Resolves #971 

Currently there is an issue with `bookmark-line`/`bookmark-fill` and `book-mark-line`/`book-mark-fill`. The pascal cased names conflict in the OS.


Broke it into 2 packs, `remix-fill` and `remix-line`

![image](https://user-images.githubusercontent.com/855184/65628684-938c1e00-df97-11e9-834a-865ba0d843fa.png)

![image](https://user-images.githubusercontent.com/855184/65628666-88d18900-df97-11e9-9d30-7b6fff31959a.png)

@jacobwgillespie 