### PR TITLE
Use StyledIcon type in generated .d.ts files

### DIFF
--- a/tools/builder/templates/icon.tsx.template
+++ b/tools/builder/templates/icon.tsx.template
@@ -1,7 +1,7 @@
 import * as React from 'react'
-import {StyledIconBase, StyledIconProps} from '@styled-icons/styled-icon'
+import {StyledIcon, StyledIconBase, StyledIconProps} from '@styled-icons/styled-icon'
 
-export const {{name}} = React.forwardRef<SVGSVGElement, StyledIconProps>((props, ref) => {
+export const {{name}}: StyledIcon = React.forwardRef<SVGSVGElement, StyledIconProps>((props, ref) => {
   const attrs: React.SVGProps<SVGSVGElement> = {
     {{attrs}},
   }


### PR DESCRIPTION
Fixes #1077

TypeScript is expanding the type inside the generated icon type in a way that's incompatible with the actual SVG type.  This uses `StyledIcon` in the generated types, which refers directly to `React.SVGProps` which fixes the issue.