### PR TITLE
Add nested peer dependencies

### DIFF
--- a/packages/@styled-icons/boxicons-logos/package.json
+++ b/packages/@styled-icons/boxicons-logos/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/tsconfig": "^9.0.0",
     "boxicons": "2.0.5"

--- a/packages/@styled-icons/boxicons-regular/package.json
+++ b/packages/@styled-icons/boxicons-regular/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/boxicons-solid/package.json
+++ b/packages/@styled-icons/boxicons-solid/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/crypto/package.json
+++ b/packages/@styled-icons/crypto/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/evil/package.json
+++ b/packages/@styled-icons/evil/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/fa-brands/package.json
+++ b/packages/@styled-icons/fa-brands/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.27",
     "@fortawesome/free-brands-svg-icons": "5.12.1",

--- a/packages/@styled-icons/fa-regular/package.json
+++ b/packages/@styled-icons/fa-regular/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.27",
     "@fortawesome/free-regular-svg-icons": "5.12.1",

--- a/packages/@styled-icons/fa-solid/package.json
+++ b/packages/@styled-icons/fa-solid/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@fortawesome/fontawesome-svg-core": "1.2.27",
     "@fortawesome/free-solid-svg-icons": "5.12.1",

--- a/packages/@styled-icons/feather/package.json
+++ b/packages/@styled-icons/feather/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/icomoon/package.json
+++ b/packages/@styled-icons/icomoon/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/icomoon-source": "Keyamoon/IcoMoon-Free#d006795ede82361e1bac1ee76f215cf1dc51e4ca",
     "@styled-icons/pack-builder": "^9.4.0",

--- a/packages/@styled-icons/material/package.json
+++ b/packages/@styled-icons/material/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/octicons/package.json
+++ b/packages/@styled-icons/octicons/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@primer/octicons": "9.4.0",
     "@styled-icons/pack-builder": "^9.4.0",

--- a/packages/@styled-icons/remix-fill/package.json
+++ b/packages/@styled-icons/remix-fill/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/remix-line/package.json
+++ b/packages/@styled-icons/remix-line/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",

--- a/packages/@styled-icons/typicons/package.json
+++ b/packages/@styled-icons/typicons/package.json
@@ -21,6 +21,10 @@
     "@styled-icons/styled-icon": "^9.2.0",
     "tslib": "^1.9.3"
   },
+  "peerDependencies": {
+    "react": "*",
+    "styled-components": "*"
+  },
   "devDependencies": {
     "@styled-icons/pack-builder": "^9.4.0",
     "@styled-icons/tsconfig": "^9.0.0",


### PR DESCRIPTION
This diff adds the missing peer dependencies on all of the `@styled-icons/*` packages. Without that, Yarn 2 will refuse giving access to the dependencies.

See [PR 975 in yarnpkg/berry](https://github.com/yarnpkg/berry/pull/975).