### PR TITLE
Styled Icons v10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v10.0.0 - 2020-02-26
+
+Styled Icons v10 introduces individual NPM modules for icon packs, originally introduced in v9, as the preferred way to install Styled Icons. It also deprecates single icon imports (`styled-icons/PACK/ICON`) on the main `styled-icons` package in favor of the new individual icon packages (`@styled-icons/PACK/ICON`).
+
+To upgrade, you only need to update your code if you import icons individually (`styled-icons/PACK/ICON`) - you will need to change the following:
+
+```typescript
+import {Icon} from 'styled-icons/pack/icon'
+```
+
+To the following (also install the `@styled-icons/pack` module):
+
+```typescript
+import {Icon} from '@styled-icons/pack/icon'
+```
+
+All other imports from `styled-icons` still function as before (for instance `import {Icon} from 'styled-icons/pack'`), though you are welcome to migrate to the new `@styled-icons/PACK` modules. See the README for a list of icon packs.
+
+- **(breaking)** Remove individual icon imports from the `styled-icons` package (`styled-icons/PACK/ICON`)
+- Update documentation to introduce new `@styled-icons/PACK` NPM modules as the first-class install method
+
 ## v9.6.0 - 2020-02-25
 
 - Add Material icon variants (`material-outlined`, `material-rounded`, `material-sharp`, `material-twotone`)

--- a/packages/styled-icons/README.md
+++ b/packages/styled-icons/README.md
@@ -8,7 +8,7 @@
 
 [![View Icons](https://gui.apex.sh/component?name=ShadowButton&config=%7B%22text%22%3A%22ICON%20EXPLORER%22%2C%22color%22%3A%22db7093%22%7D)](https://styled-icons.js.org)
 
-`styled-icons` provides the following icon packs as [Styled Components](https://www.styled-components.com/), with full support for TypeScript types and tree-shaking / ES modules:
+`styled-icons` provides over 13,500 icons from the following icon packs as [Styled Components](https://www.styled-components.com/), with full support for TypeScript types and tree-shaking / ES modules:
 
 - [Boxicons](https://boxicons.com/)
 - [Crypto Icons](http://cryptoicons.co)
@@ -34,6 +34,7 @@
   - [Props](#props)
   - [Icon Dimensions](#icon-dimensions)
   - [Styled Components](#styled-components)
+  - [Base Icon Styles](#base-icon-styles)
   - [Accessibility](#accessibility)
   - [Tree Shaking](#tree-shaking)
   - [TypeScript](#typescript)
@@ -42,6 +43,8 @@
 - [Contributors](#contributors)
 
 ## Installation
+
+You can install all the icon packs simultaneously:
 
 ```
 yarn add styled-icons
@@ -53,7 +56,36 @@ or
 npm install styled-icons --save
 ```
 
-Additionally, you will need to have installed a version of `styled-components` at least version 4.1.0 or newer, as `styled-icons` depends on `styled-components` as a peer dependency.
+Alternatively you can install only the icon packs you need:
+
+```
+yarn add @styled-icons/boxicons-logos
+yarn add @styled-icons/boxicons-regular
+yarn add @styled-icons/boxicons-solid
+yarn add @styled-icons/crypto
+yarn add @styled-icons/entypo
+yarn add @styled-icons/entypo-social
+yarn add @styled-icons/evil
+yarn add @styled-icons/fa-brands
+yarn add @styled-icons/fa-regular
+yarn add @styled-icons/fa-solid
+yarn add @styled-icons/feather
+yarn add @styled-icons/foundation
+yarn add @styled-icons/heroicons-outline
+yarn add @styled-icons/heroicons-solid
+yarn add @styled-icons/icomoon
+yarn add @styled-icons/material
+yarn add @styled-icons/material-outlined
+yarn add @styled-icons/material-rounded
+yarn add @styled-icons/material-twotone
+yarn add @styled-icons/material-sharp
+yarn add @styled-icons/octicons
+yarn add @styled-icons/open-iconic
+yarn add @styled-icons/typicons
+yarn add @styled-icons/zondicons
+```
+
+Finally, you will need to have installed a version of `styled-components` at least version 4.1.0 or newer, as `styled-icons` depends on `styled-components` as a peer dependency.
 
 ## Usage
 
@@ -64,37 +96,37 @@ The entire icon packs are available via the main import and sub-imports:
 ```javascript
 import {material, octicons} from 'styled-icons'
 
-import * as boxiconsLogos from 'styled-icons/boxicons-logos'
-import * as boxiconsRegular from 'styled-icons/boxicons-regular'
-import * as boxiconsSolid from 'styled-icons/boxicons-solid'
-import * as crypto from 'styled-icons/crypto'
-import * as entypo from 'styled-icons/entypo'
-import * as entypoSocial from 'styled-icons/entypo-social'
-import * as evil from 'styled-icons/evil'
-import * as faBrands from 'styled-icons/fa-brands'
-import * as faRegular from 'styled-icons/fa-regular'
-import * as faSolid from 'styled-icons/fa-solid'
-import * as feather from 'styled-icons/feather'
-import * as foundation from 'styled-icons/foundation'
-import * as heroiconsOutline from 'styled-icons/heroicons-outline'
-import * as heroiconsSolid from 'styled-icons/heroicons-solid'
-import * as icomoon from 'styled-icons/icomoon'
-import * as material from 'styled-icons/material'
-import * as materialOutlined from 'styled-icons/material-outlined'
-import * as materialRounded from 'styled-icons/material-rounded'
-import * as materialTwoTone from 'styled-icons/material-twotone'
-import * as materialSharp from 'styled-icons/material-sharp'
-import * as octicons from 'styled-icons/octicons'
-import * as openIconic from 'styled-icons/open-iconic'
-import * as typicons from 'styled-icons/typicons'
-import * as zondicons from 'styled-icons/zondicons'
+import * as boxiconsLogos from '@styled-icons/boxicons-logos'
+import * as boxiconsRegular from '@styled-icons/boxicons-regular'
+import * as boxiconsSolid from '@styled-icons/boxicons-solid'
+import * as crypto from '@styled-icons/crypto'
+import * as entypo from '@styled-icons/entypo'
+import * as entypoSocial from '@styled-icons/entypo-social'
+import * as evil from '@styled-icons/evil'
+import * as faBrands from '@styled-icons/fa-brands'
+import * as faRegular from '@styled-icons/fa-regular'
+import * as faSolid from '@styled-icons/fa-solid'
+import * as feather from '@styled-icons/feather'
+import * as foundation from '@styled-icons/foundation'
+import * as heroiconsOutline from '@styled-icons/heroicons-outline'
+import * as heroiconsSolid from '@styled-icons/heroicons-solid'
+import * as icomoon from '@styled-icons/icomoon'
+import * as material from '@styled-icons/material'
+import * as materialOutlined from '@styled-icons/material-outlined'
+import * as materialRounded from '@styled-icons/material-rounded'
+import * as materialTwoTone from '@styled-icons/material-twotone'
+import * as materialSharp from '@styled-icons/material-sharp'
+import * as octicons from '@styled-icons/octicons'
+import * as openIconic from '@styled-icons/open-iconic'
+import * as typicons from '@styled-icons/typicons'
+import * as zondicons from '@styled-icons/zondicons'
 ```
 
-The icons are also available as individual imports - it is recommended that you import icons individually using ES modules along with a module bundler like Webpack or Rollup in order to enable tree-shaking. This means that the module bundler will remove unused icons from the final JavaScript bundle, saving bandwidth and speeding up loading:
+You can also import just the icons you need:
 
 ```javascript
 import React, {Fragment} from 'react'
-import {AccountCircle, Lock} from 'styled-icons/material'
+import {AccountCircle, Lock} from '@styled-icons/material'
 
 const App = () => (
   <Fragment>
@@ -102,6 +134,15 @@ const App = () => (
     <Lock />
   </Fragment>
 )
+```
+
+For the individual icon pack packages (`@styled-icons/PACK`), the icons are also importable individually - this is not possible with the uber-`styled-icons` package containing all the packs:
+
+```javascript
+import React from 'react'
+import {Lock} from '@styled-icons/material/Lock'
+
+const App = () => <Lock />
 ```
 
 ### Props
@@ -117,7 +158,7 @@ Styled Icons accept all the valid props of an `<svg />` element, in addition to 
 
 ```javascript
 import React from 'react'
-import {Lock} from 'styled-icons/material'
+import {Lock} from '@styled-icons/material'
 
 const App = () => <Lock size="48" title="Unlock account" />
 ```
@@ -127,7 +168,7 @@ const App = () => <Lock size="48" title="Unlock account" />
 Some icons natively have non-square dimensions - original dimensions are exported from the individual icon exports:
 
 ```javascript
-import {LogoGithub, LogoGithubDimensions} from 'styled-icons/octicons/LogoGithub'
+import {LogoGithub, LogoGithubDimensions} from '@styled-icons/octicons/LogoGithub'
 
 const App = () => <LogoGithub />
 
@@ -137,7 +178,7 @@ console.log(LogoGithubDimension) // {height: 16, width: 45}
 Dimension exports are not available on the icon pack or index exports:
 
 ```javascript
-import * as octicons from 'styled-icons/octicons'
+import * as octicons from '@styled-icons/octicons'
 import {octicons} from 'styled-icons'
 
 // octicons contains only icon exports
@@ -149,12 +190,28 @@ All icons are exported as [Styled Components](https://www.styled-components.com/
 
 ```javascript
 import styled from 'styled-components'
-import {Lock} from 'styled-icons/material'
+import {Lock} from '@styled-icons/material'
 
 export const RedLock = styled(Lock)`
   color: red;
 
   font-weight: ${props => (props.important ? 'bold' : 'normal')};
+`
+```
+
+### Base Icon Styles
+
+If you wish to style all icons at once, you can create a wrapper styled component that imparts a particular style to all icons contained within the wrapper by targeting the `StyledIconBase` component:
+
+```javascript
+import styled from 'styled-components'
+import {StyledIconBase} from '@styled-icons/styled-icon'
+
+export const IconStyleWrapper = styled.div`
+  ${StyledIconBase} {
+    color: red;
+    /* icon styles go here */
+  }
 `
 ```
 
@@ -186,7 +243,7 @@ As this library provides direct access to the `<svg>` element, you may wish to f
 
 ```javascript
 import styled from 'styled-components'
-import {Spinner} from 'styled-icons/fa-solid/Spinner'
+import {Spinner} from '@styled-icons/fa-solid/Spinner'
 
 const VisuallyHidden = styled.span`
   border: 0 !important;
@@ -214,10 +271,14 @@ Styled Icons supports automatic tree-shaking via the `package.json` `module` pro
 
 ### TypeScript
 
-The icons of `styled-icons` are built using TypeScript and export type definitions. If you need a type to reference any styled icon, there is a `StyledIcon` type exported from the `styled-icons/types` import:
+The icons of `styled-icons` are built using TypeScript and export type definitions. If you need a type to reference any styled icon, there is a `StyledIcon` type exported from the `@styled-icons/styled-icon` package (recommended) or the `styled-icons/types` import:
 
 ```typescript
 import styled from 'styled-components'
+
+// Recommended:
+import {StyledIcon} from '@styled-icons/styled-icon'
+// Alternatively:
 import {StyledIcon} from 'styled-icons/types'
 
 interface Props {

--- a/packages/website/src/IndexPage.tsx
+++ b/packages/website/src/IndexPage.tsx
@@ -36,7 +36,7 @@ const IndexPage: React.SFC = () => (
       <code className="demo">
         {`
 import styled from 'styled-components'
-import {Zap} from 'styled-icons/octicons/Zap'
+import {Zap} from '@styled-icons/octicons'
 
 const RedZap = styled(Zap)\`
   color: red;

--- a/packages/website/src/components/IconCard.tsx
+++ b/packages/website/src/components/IconCard.tsx
@@ -50,7 +50,7 @@ interface Props {
 export const IconCard: React.SFC<Props> = ({name, pack}) => {
   const isMounted = useIsMounted()
   const [copied, setCopied] = useState(false)
-  const iconImport = useMemo(() => `styled-icons/${pack}/${name}`, [pack, name])
+  const iconImport = useMemo(() => `@styled-icons/${pack}/${name}`, [pack, name])
   const [Icon, setIcon] = useState<StyledIcon | null>(null)
 
   const copyCallback = useCallback(() => {

--- a/tools/builder/build-mono-package.js
+++ b/tools/builder/build-mono-package.js
@@ -37,16 +37,7 @@ async function run() {
     await fs.mkdirp(packName)
 
     await fs.writeFile(path.join(packName, 'package.json'), pkgJSON('index'))
-    await fs.writeFile(path.join(packName, 'index.ts'), pack.map(icon => `export * from './${icon.name}'`).join('\n'))
-
-    for (const icon of pack) {
-      await fs.mkdirp(path.join(icon.pack, icon.name))
-      await fs.writeFile(path.join(icon.pack, icon.name, 'package.json'), pkgJSON(icon.name))
-      await fs.writeFile(
-        path.join(icon.pack, icon.name, `${icon.name}.ts`),
-        `export * from '@styled-icons/${icon.pack}/${icon.name}'`,
-      )
-    }
+    await fs.writeFile(path.join(packName, 'index.ts'), `export * from '@styled-icons/${packName}'`)
   }
   await fs.mkdirp('types')
   await fs.writeFile(
@@ -95,9 +86,6 @@ export {${packs.map(pack => fastCase.camelize(pack[0].pack)).join(', ')}}
   console.log('Generating package.json files')
   for (const pack of packs) {
     await fs.writeFile(path.join(pack[0].pack, 'package.json'), pkgJSONBuilt('index'))
-    for (const icon of pack) {
-      await fs.writeFile(path.join(icon.pack, icon.name, 'package.json'), pkgJSONBuilt(icon.name))
-    }
   }
   await fs.writeFile(path.join('types', 'package.json'), pkgJSONBuilt('types'))
 


### PR DESCRIPTION
Removes the `styled-icons/PACK/ICON` exports, updates docs to recommend `@styled-icons/PACK` packages.

Fixes #1171 