### PR TITLE
Unblock people who want to upgrade

### DIFF
--- a/.changeset/mean-rivers-film.md
+++ b/.changeset/mean-rivers-film.md
@@ -1,0 +1,6 @@
+---
+"styled-icons": patch
+"@styled-icons/styled-icon": patch
+---
+
+Relax peer dependency requirement for `styled-components`

--- a/packages/@styled-icons/styled-icon/package.json
+++ b/packages/@styled-icons/styled-icon/package.json
@@ -28,7 +28,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "styled-components": ">=4.1.0 <6"
+    "styled-components": ">=4.1.0"
   },
   "devDependencies": {
     "@styled-icons/pack-builder": "^10.6.0",

--- a/packages/styled-icons/package.json
+++ b/packages/styled-icons/package.json
@@ -74,7 +74,7 @@
   },
   "peerDependencies": {
     "react": "*",
-    "styled-components": ">=4.1.0 <6"
+    "styled-components": ">=4.1.0"
   },
   "devDependencies": {
     "@styled-icons/pack-builder": "^10.7.0"


### PR DESCRIPTION
With this, the default will be to allow any future styled-components major version. This will be [lower-maintenance for Styled Icons](https://github.com/styled-icons/styled-icons/issues/2131#issuecomment-1992268053), since the chances of Styled Components breaking in a way that affects Styled Icons seems _very low_, and thus Styled Icons automatically supports future versions without adding overhead to the project.